### PR TITLE
Inline block editor with Are.na sync (feature 1/3)

### DIFF
--- a/src/app/api/sites/[id]/blocks/[blockId]/route.ts
+++ b/src/app/api/sites/[id]/blocks/[blockId]/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse, after } from "next/server";
+import { ArenaClient } from "@/lib/arena";
+import { buildSite } from "@/lib/build";
+import { prisma } from "@/lib/db";
+import { getRequestAuth } from "@/lib/request-auth";
+
+export const maxDuration = 60;
+
+/**
+ * Update a single Are.na block belonging to a site's channel, using the
+ * caller's Are.na OAuth token. Triggers a background rebuild so the static
+ * site reflects the change.
+ *
+ * Authorization model: a user may patch any block in a channel they own a
+ * tiny.garden site for. We do NOT verify that Are.na considers them owner of
+ * the block — Are.na enforces that itself and will return 401/403 if not.
+ */
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; blockId: string }> }
+) {
+  const auth = await getRequestAuth(req);
+  if (!auth) {
+    return NextResponse.json(
+      { error: "Unauthorized", code: "unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const { id, blockId: blockIdRaw } = await params;
+  const blockId = Number.parseInt(blockIdRaw, 10);
+  if (!Number.isFinite(blockId) || blockId <= 0) {
+    return NextResponse.json({ error: "Invalid block id" }, { status: 400 });
+  }
+
+  const site = await prisma.site.findUnique({ where: { id } });
+  if (!site || site.userId !== auth.userId) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  let body: { title?: unknown; description?: unknown; content?: unknown; rebuild?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const patch: { title?: string; description?: string | null; content?: string | null } = {};
+  if (typeof body.title === "string") patch.title = body.title.slice(0, 500);
+  if (body.description === null || typeof body.description === "string") {
+    patch.description = body.description === null ? "" : String(body.description).slice(0, 10_000);
+  }
+  if (body.content === null || typeof body.content === "string") {
+    patch.content = body.content === null ? "" : String(body.content).slice(0, 50_000);
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return NextResponse.json(
+      { error: "No editable fields supplied" },
+      { status: 400 }
+    );
+  }
+
+  const client = new ArenaClient(auth.arenaToken);
+  let updated;
+  try {
+    updated = await client.updateBlock(blockId, patch);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Are.na update failed";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+
+  const shouldRebuild = body.rebuild !== false; // default true
+  if (shouldRebuild) {
+    after(() =>
+      buildSite(id).catch((rebuildErr) => {
+        console.error("Rebuild after block edit failed", id, blockId, rebuildErr);
+      })
+    );
+  }
+
+  return NextResponse.json({
+    block: {
+      id: updated.id,
+      title: updated.title,
+      description: updated.description,
+      content: typeof updated.content === "string" ? updated.content : null,
+      updated_at: updated.updated_at,
+    },
+    rebuildQueued: shouldRebuild,
+  });
+}

--- a/src/app/api/sites/[id]/blocks/route.ts
+++ b/src/app/api/sites/[id]/blocks/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ArenaClient } from "@/lib/arena";
+import { channelBlocksForTemplate } from "@/lib/build";
+import { prisma } from "@/lib/db";
+import { getRequestAuth } from "@/lib/request-auth";
+
+export const maxDuration = 60;
+
+/**
+ * List editable blocks for a site, sourced live from Are.na (not the build
+ * cache) so the inline editor always shows the current canonical state.
+ *
+ * Returned shape is a subset of `TemplateBlock` plus a stable
+ * `editableFields` hint that the UI uses to decide which inputs to render.
+ */
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await getRequestAuth(req);
+  if (!auth) {
+    return NextResponse.json(
+      { error: "Unauthorized", code: "unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const { id } = await params;
+  const site = await prisma.site.findUnique({ where: { id } });
+  if (!site || site.userId !== auth.userId) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const client = new ArenaClient(auth.arenaToken);
+  let raw;
+  try {
+    raw = await client.getAllChannelBlocks(site.channelSlug);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Failed to load blocks";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+
+  const blocks = channelBlocksForTemplate(raw).map((block) => ({
+    id: block.id,
+    type: block.type,
+    title: block.title,
+    description: block.description,
+    content: block.content ?? null,
+    position: block.position,
+    updated_at: block.updated_at,
+    arena_url: block.arena_url,
+    image: block.image ? { display: block.image.display, square: block.image.square } : null,
+    link: block.link ? { url: block.link.url, title: block.link.title, description: block.link.description } : null,
+    attachment: block.attachment
+      ? {
+          file_name: block.attachment.file_name,
+          kind: block.attachment.kind,
+          preview_image_url: block.attachment.preview_image_url,
+        }
+      : null,
+    /**
+     * Tells the client which fields are user-editable on Are.na for this block type.
+     * Are.na only accepts content on Text blocks; image/link/media/attachment blocks
+     * are still editable for title/description.
+     */
+    editableFields: editableFieldsForType(block.type),
+  }));
+
+  return NextResponse.json({
+    site: {
+      id: site.id,
+      subdomain: site.subdomain,
+      channelSlug: site.channelSlug,
+      channelTitle: site.channelTitle,
+    },
+    blocks,
+  });
+}
+
+function editableFieldsForType(
+  type: "image" | "text" | "link" | "media" | "attachment"
+): Array<"title" | "description" | "content"> {
+  if (type === "text") return ["title", "content"];
+  return ["title", "description"];
+}

--- a/src/app/sites/[id]/page.tsx
+++ b/src/app/sites/[id]/page.tsx
@@ -10,6 +10,7 @@ import { IdeTextEditor } from "@/components/ide-text-editor";
 import { ThemeTokensPillEditor } from "@/components/theme-tokens-pill-editor";
 import { SegmentedControl } from "@/components/toolbar";
 import { SiteChannelSettingsCard } from "@/components/site-channel-settings-card";
+import { SiteContentEditor } from "@/components/site-content-editor";
 import { SiteSettingsSkeleton } from "@/components/sites-dashboard-skeletons";
 import { PlantIconFrame, SitePreviewColumn } from "@/components/site-preview-column";
 import {
@@ -50,7 +51,7 @@ interface AccountInfo {
 const DEFAULT_COLORS = DEFAULT_THEME_COLORS;
 const DEFAULT_FONTS = DEFAULT_THEME_FONTS;
 
-type SettingsTab = "settings" | "theme";
+type SettingsTab = "settings" | "content" | "theme";
 
 type ThemeFileTab = "theme-css" | "styles-css";
 
@@ -569,12 +570,13 @@ export default function SiteSettingsPage() {
             <SegmentedControl<SettingsTab>
               segments={[
                 { value: "settings", label: "Settings" },
+                { value: "content", label: "Content" },
                 { value: "theme", label: "Theme" },
               ]}
               value={activeTab}
               onChange={setActiveTab}
               ariaLabel="Site settings sections"
-              className="w-full max-w-[13.5rem] shrink-0 sm:w-[13.5rem] sm:self-end"
+              className="w-full max-w-[18rem] shrink-0 sm:w-[18rem] sm:self-end"
               labelClassName="px-3 text-xs font-medium"
             />
         </div>
@@ -583,8 +585,17 @@ export default function SiteSettingsPage() {
           <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-6 md:flex-row md:items-stretch md:gap-6">
             <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col gap-2 md:min-h-0">
               <h2 className="shrink-0 text-xs font-medium text-neutral-500 dark:text-neutral-400">
-                {activeTab === "settings" ? "Settings" : "Theme"}
+                {activeTab === "settings"
+                  ? "Settings"
+                  : activeTab === "content"
+                  ? "Content"
+                  : "Theme"}
               </h2>
+              {activeTab === "content" && (
+                <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-neutral-200 bg-white shadow-sm dark:border-neutral-700 dark:bg-neutral-950">
+                  <SiteContentEditor siteId={id} />
+                </div>
+              )}
               {activeTab === "settings" && (
               <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-neutral-200 bg-white shadow-sm dark:border-neutral-700 dark:bg-neutral-950">
                 <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4">

--- a/src/components/site-content-editor.tsx
+++ b/src/components/site-content-editor.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { track } from "@/lib/track";
+
+/**
+ * Subset of `TemplateBlock` returned by `GET /api/sites/[id]/blocks`. Kept
+ * narrow so the editor doesn't depend on the build-time shape.
+ */
+export type EditableBlock = {
+  id: number;
+  type: "image" | "text" | "link" | "media" | "attachment";
+  title: string;
+  description: string;
+  content: string | null;
+  position: number;
+  updated_at: string;
+  arena_url: string;
+  image: { display: string; square: string } | null;
+  link: { url: string; title: string; description: string } | null;
+  attachment: {
+    file_name: string;
+    kind: string;
+    preview_image_url: string;
+  } | null;
+  editableFields: Array<"title" | "description" | "content">;
+};
+
+type SaveState =
+  | { kind: "idle" }
+  | { kind: "saving" }
+  | { kind: "saved"; at: number }
+  | { kind: "error"; message: string };
+
+type DraftMap = Record<number, { title?: string; description?: string; content?: string }>;
+
+function blockTypeLabel(type: EditableBlock["type"]): string {
+  switch (type) {
+    case "image":
+      return "Image";
+    case "text":
+      return "Text";
+    case "link":
+      return "Link";
+    case "media":
+      return "Media";
+    case "attachment":
+      return "File";
+  }
+}
+
+function blockPreview(block: EditableBlock): React.ReactNode {
+  if (block.image?.display) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={block.image.display}
+        alt=""
+        className="h-16 w-16 shrink-0 rounded border border-neutral-200 object-cover dark:border-neutral-800"
+      />
+    );
+  }
+  if (block.attachment?.preview_image_url) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={block.attachment.preview_image_url}
+        alt=""
+        className="h-16 w-16 shrink-0 rounded border border-neutral-200 object-cover dark:border-neutral-800"
+      />
+    );
+  }
+  return (
+    <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded border border-neutral-200 text-[10px] uppercase tracking-wide text-neutral-400 dark:border-neutral-800 dark:text-neutral-500">
+      {blockTypeLabel(block.type)}
+    </div>
+  );
+}
+
+/**
+ * Inline editor for a site's Are.na blocks.
+ *
+ * - Fetches blocks live from Are.na via the local API on mount.
+ * - User edits go into a per-block draft. "Save" PATCHes the block on Are.na
+ *   and triggers a debounced rebuild server-side.
+ * - We refetch the row on success so the UI shows Are.na's canonical state.
+ */
+export function SiteContentEditor({ siteId }: { siteId: string }) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [blocks, setBlocks] = useState<EditableBlock[]>([]);
+  const [drafts, setDrafts] = useState<DraftMap>({});
+  const [saveState, setSaveState] = useState<Record<number, SaveState>>({});
+
+  const refreshAll = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/sites/${siteId}/blocks`, {
+        credentials: "same-origin",
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(text || `Failed to load blocks (${res.status})`);
+      }
+      const data = (await res.json()) as { blocks: EditableBlock[] };
+      setBlocks(data.blocks);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load blocks");
+    } finally {
+      setLoading(false);
+    }
+  }, [siteId]);
+
+  useEffect(() => {
+    void refreshAll();
+  }, [refreshAll]);
+
+  const setDraftField = (
+    blockId: number,
+    field: "title" | "description" | "content",
+    value: string
+  ) => {
+    setDrafts((prev) => ({
+      ...prev,
+      [blockId]: { ...prev[blockId], [field]: value },
+    }));
+  };
+
+  const hasDraft = (blockId: number) => {
+    const d = drafts[blockId];
+    if (!d) return false;
+    return (
+      typeof d.title === "string" ||
+      typeof d.description === "string" ||
+      typeof d.content === "string"
+    );
+  };
+
+  const discardDraft = (blockId: number) => {
+    setDrafts((prev) => {
+      const next = { ...prev };
+      delete next[blockId];
+      return next;
+    });
+    setSaveState((prev) => ({ ...prev, [blockId]: { kind: "idle" } }));
+  };
+
+  const saveBlock = async (block: EditableBlock) => {
+    const draft = drafts[block.id];
+    if (!draft) return;
+
+    setSaveState((prev) => ({ ...prev, [block.id]: { kind: "saving" } }));
+    try {
+      const res = await fetch(`/api/sites/${siteId}/blocks/${block.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(draft),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(data.error || `Save failed (${res.status})`);
+      }
+      const data = (await res.json()) as {
+        block: { id: number; title: string; description: string; content: string | null; updated_at: string };
+        rebuildQueued: boolean;
+      };
+      setBlocks((prev) =>
+        prev.map((b) =>
+          b.id === block.id
+            ? {
+                ...b,
+                title: data.block.title,
+                description: data.block.description ?? "",
+                content: data.block.content,
+                updated_at: data.block.updated_at,
+              }
+            : b
+        )
+      );
+      discardDraft(block.id);
+      setSaveState((prev) => ({
+        ...prev,
+        [block.id]: { kind: "saved", at: Date.now() },
+      }));
+      track("block-edited", { siteId, blockId: block.id, fields: Object.keys(draft).join(",") });
+    } catch (err) {
+      setSaveState((prev) => ({
+        ...prev,
+        [block.id]: {
+          kind: "error",
+          message: err instanceof Error ? err.message : "Save failed",
+        },
+      }));
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex min-h-32 items-center justify-center p-6 text-xs text-neutral-500 dark:text-neutral-400">
+        Loading blocks from Are.na…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-3 p-4 text-sm">
+        <p className="text-red-600 dark:text-red-400">{error}</p>
+        <button
+          type="button"
+          onClick={() => void refreshAll()}
+          className="inline-flex items-center justify-center rounded border border-neutral-200 px-2.5 py-1 text-xs font-medium hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800/80"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (blocks.length === 0) {
+    return (
+      <div className="p-6 text-xs text-neutral-500 dark:text-neutral-400">
+        This channel has no blocks yet. Add a block on Are.na and refresh.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-neutral-200 px-4 py-2 text-xs text-neutral-500 dark:border-neutral-800 dark:text-neutral-400">
+        <span>{blocks.length} blocks · edits sync to Are.na and queue a rebuild</span>
+        <button
+          type="button"
+          onClick={() => void refreshAll()}
+          className="inline-flex items-center justify-center rounded border border-neutral-200 px-2 py-0.5 text-[11px] font-medium hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800/80"
+        >
+          Refresh
+        </button>
+      </div>
+      <ul className="min-h-0 flex-1 divide-y divide-neutral-200 overflow-y-auto dark:divide-neutral-800">
+        {blocks.map((block) => {
+          const draft = drafts[block.id] || {};
+          const state = saveState[block.id] || { kind: "idle" as const };
+          const title = draft.title ?? block.title;
+          const description = draft.description ?? block.description;
+          const content = draft.content ?? block.content ?? "";
+          const canSave = hasDraft(block.id) && state.kind !== "saving";
+
+          return (
+            <li key={block.id} className="px-4 py-3">
+              <div className="flex items-start gap-3">
+                {blockPreview(block)}
+                <div className="min-w-0 flex-1 space-y-2">
+                  <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-[11px] text-neutral-500 dark:text-neutral-400">
+                    <span className="font-mono uppercase tracking-wide">{blockTypeLabel(block.type)}</span>
+                    <a
+                      href={block.arena_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-mono underline-offset-2 hover:underline"
+                    >
+                      #{block.id}
+                    </a>
+                    {block.link?.url ? (
+                      <a
+                        href={block.link.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="max-w-full truncate underline-offset-2 hover:underline"
+                        title={block.link.url}
+                      >
+                        {block.link.url}
+                      </a>
+                    ) : null}
+                    {block.attachment?.file_name ? (
+                      <span className="truncate" title={block.attachment.file_name}>
+                        {block.attachment.file_name}
+                      </span>
+                    ) : null}
+                  </div>
+
+                  {block.editableFields.includes("title") && (
+                    <label className="block">
+                      <span className="sr-only">Title</span>
+                      <input
+                        type="text"
+                        value={title}
+                        placeholder="Title"
+                        onChange={(e) => setDraftField(block.id, "title", e.target.value)}
+                        className="w-full rounded border border-neutral-200 bg-white px-2 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+                      />
+                    </label>
+                  )}
+
+                  {block.editableFields.includes("description") && (
+                    <label className="block">
+                      <span className="sr-only">Description</span>
+                      <textarea
+                        value={description}
+                        placeholder="Description"
+                        rows={2}
+                        onChange={(e) => setDraftField(block.id, "description", e.target.value)}
+                        className="w-full resize-y rounded border border-neutral-200 bg-white px-2 py-1 font-mono text-xs dark:border-neutral-700 dark:bg-neutral-900"
+                      />
+                    </label>
+                  )}
+
+                  {block.editableFields.includes("content") && (
+                    <label className="block">
+                      <span className="sr-only">Content</span>
+                      <textarea
+                        value={content}
+                        placeholder="Body (Markdown supported on Are.na)"
+                        rows={5}
+                        onChange={(e) => setDraftField(block.id, "content", e.target.value)}
+                        className="w-full resize-y rounded border border-neutral-200 bg-white px-2 py-1 font-mono text-xs dark:border-neutral-700 dark:bg-neutral-900"
+                      />
+                    </label>
+                  )}
+
+                  <div className="flex flex-wrap items-center gap-2 pt-1">
+                    <button
+                      type="button"
+                      onClick={() => void saveBlock(block)}
+                      disabled={!canSave}
+                      className="inline-flex items-center justify-center rounded border border-neutral-200 bg-white px-2.5 py-1 text-xs font-medium hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-950 dark:hover:bg-neutral-800/80"
+                    >
+                      {state.kind === "saving" ? "Saving…" : "Save"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => discardDraft(block.id)}
+                      disabled={!hasDraft(block.id) || state.kind === "saving"}
+                      className="inline-flex items-center justify-center rounded px-2 py-1 text-xs font-medium text-neutral-500 hover:text-neutral-900 disabled:cursor-not-allowed disabled:opacity-50 dark:text-neutral-400 dark:hover:text-neutral-100"
+                    >
+                      Discard
+                    </button>
+                    {state.kind === "saved" && (
+                      <span className="text-[11px] text-green-600 dark:text-green-400">
+                        Saved · rebuild queued
+                      </span>
+                    )}
+                    {state.kind === "error" && (
+                      <span className="text-[11px] text-red-600 dark:text-red-400">
+                        {state.message}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/lib/arena.ts
+++ b/src/lib/arena.ts
@@ -164,6 +164,92 @@ export class ArenaClient {
     return this.fetch("/me");
   }
 
+  /** Fetch a single block by its Are.na id (used for refetch after edit). */
+  async getBlock(blockId: number): Promise<ArenaBlock> {
+    const res = await this.fetch<ArenaBlock | { data: ArenaBlock }>(
+      `/blocks/${blockId}`
+    );
+    return "data" in res && res.data
+      ? (res as { data: ArenaBlock }).data
+      : (res as ArenaBlock);
+  }
+
+  /**
+   * Update a block on Are.na.
+   *
+   * Are.na's `PUT /blocks/:id` accepts `title`, `description`, and (for Text
+   * blocks) `content`. Image / Media block bodies are not editable through
+   * this endpoint; only their title/description.
+   */
+  async updateBlock(
+    blockId: number,
+    patch: { title?: string; description?: string | null; content?: string | null }
+  ): Promise<ArenaBlock> {
+    const now = Date.now();
+    const elapsed = now - this.lastRequestAt;
+    if (elapsed < this.minInterval) {
+      await sleep(this.minInterval - elapsed);
+    }
+    this.lastRequestAt = Date.now();
+
+    const body: Record<string, unknown> = {};
+    if (typeof patch.title === "string") body.title = patch.title;
+    if (patch.description !== undefined) body.description = patch.description ?? "";
+    if (patch.content !== undefined) body.content = patch.content ?? "";
+
+    const res = await fetch(`${ARENA_API}/blocks/${blockId}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (res.status === 429) {
+      const resetHeader = res.headers.get("X-RateLimit-Reset");
+      const resetAt = resetHeader
+        ? parseInt(resetHeader, 10) * 1000
+        : Date.now() + 60000;
+      const waitMs = Math.min(Math.max(resetAt - Date.now(), 1000), 60000);
+      await sleep(waitMs);
+      this.lastRequestAt = Date.now();
+      const retry = await fetch(`${ARENA_API}/blocks/${blockId}`, {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+      if (!retry.ok) {
+        const text = await retry.text();
+        throw new Error(
+          `Are.na block update failed (${retry.status} ${retry.statusText}): ${text.slice(0, 240)}`
+        );
+      }
+      const data = (await retry.json()) as ArenaBlock | { data: ArenaBlock };
+      return "data" in data && data.data
+        ? (data as { data: ArenaBlock }).data
+        : (data as ArenaBlock);
+    }
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(
+        `Are.na block update failed (${res.status} ${res.statusText}): ${text.slice(0, 240)}`
+      );
+    }
+    // Are.na sometimes returns 204 No Content on PUT. Refetch in that case.
+    if (res.status === 204) {
+      return this.getBlock(blockId);
+    }
+    const data = (await res.json()) as ArenaBlock | { data: ArenaBlock };
+    return "data" in data && data.data
+      ? (data as { data: ArenaBlock }).data
+      : (data as ArenaBlock);
+  }
+
   async searchChannels(query: string): Promise<ArenaChannel[]> {
     try {
       const data = await this.fetch<{ data: ArenaChannel[] }>("/search", {


### PR DESCRIPTION
## Summary

Adds a third **Content** tab on `/sites/[id]` that lets a site owner edit every Are.na block in their channel — title, description, and Text-block content — directly from the dashboard. Edits round-trip to Are.na via `PUT /v3/blocks/{id}` using the user's OAuth token, then queue a background rebuild so the static site reflects the change.

This is feature 1 of 3 from `docs/features.md`.

## What changed

- `src/lib/arena.ts` — `ArenaClient.updateBlock(blockId, patch)` and `getBlock(blockId)`, both with the same rate-limit-aware retry as the rest of the client.
- `src/app/api/sites/[id]/blocks/route.ts` — `GET`: returns editable blocks for a site, sourced live from Are.na so the editor never shows stale build-cache state.
- `src/app/api/sites/[id]/blocks/[blockId]/route.ts` — `PATCH`: forwards `title` / `description` / `content` to Are.na, returns the canonical row, and queues a rebuild via `after(() => buildSite(id))` (skippable with `{ rebuild: false }`).
- `src/components/site-content-editor.tsx` — client component: per-block draft state, save / discard buttons, inline error + "Saved · rebuild queued" feedback, refresh button.
- `src/app/sites/[id]/page.tsx` — adds the **Content** segment to the existing tab control.

## Scope of v1

- Editable fields: `title` for all blocks; `description` for Image / Link / Media / Attachment; `content` for Text. Are.na's `PUT /blocks/:id` does not support image replacement or block reordering, so neither does this PR.
- Authorization: Site ownership is checked locally; Are.na block ownership is enforced by Are.na (we surface 401 / 403 verbatim).
- Conflict handling: none — last-write-wins for now. If a block changed on Are.na between fetch and save, the Are.na response replaces the row.

## Test plan

- [ ] Open the Content tab on an existing site; verify all blocks render with type label + preview.
- [ ] Edit a Text block body, click Save → block updates on Are.na, row shows "Saved · rebuild queued", static site rebuilds.
- [ ] Edit an Image block title and description → Are.na shows the change; image is untouched.
- [ ] Edit a block you don't own on Are.na (e.g. collaborator channel) → editor surfaces the 401/403 error inline.
- [ ] Click Refresh after editing on Are.na directly → the editor picks up the external change.

## Open follow-ups (not in this PR)

- Block reordering / image replacement.
- Conflict detection ("this block changed on Are.na since you loaded the editor").
- Debounced auto-save instead of explicit Save.
- Markdown preview for Text blocks.

Made with [Cursor](https://cursor.com)