### PR TITLE
Create Are.na blocks and channels from tiny.garden (feature 2/3)

### DIFF
--- a/src/app/api/channels/route.ts
+++ b/src/app/api/channels/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { getRequestAuth } from "@/lib/request-auth";
 import { ArenaClient } from "@/lib/arena";
 
+export const maxDuration = 30;
+
 export async function GET(req: NextRequest) {
   const auth = await getRequestAuth(req);
   if (!auth)
@@ -37,5 +39,72 @@ export async function GET(req: NextRequest) {
   } catch (error) {
     console.error(`Failed to fetch channels (${source}):`, error);
     return NextResponse.json([], { status: 200 });
+  }
+}
+
+/**
+ * Create a new Are.na channel owned by the authenticated user.
+ *
+ * Body: `{ title: string; status?: "public" | "closed" | "private" }`.
+ *
+ * Returns the new channel as Are.na reports it (we trust their canonical slug
+ * and id rather than guessing from the title).
+ */
+export async function POST(req: NextRequest) {
+  const auth = await getRequestAuth(req);
+  if (!auth) {
+    return NextResponse.json(
+      { error: "Unauthorized", code: "unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  let body: { title?: unknown; status?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const title = typeof body.title === "string" ? body.title.trim() : "";
+  if (!title) {
+    return NextResponse.json({ error: "title is required" }, { status: 400 });
+  }
+  if (title.length > 200) {
+    return NextResponse.json(
+      { error: "title is too long (max 200 chars)" },
+      { status: 400 }
+    );
+  }
+
+  let status: "public" | "closed" | "private" | undefined;
+  if (
+    body.status === "public" ||
+    body.status === "closed" ||
+    body.status === "private"
+  ) {
+    status = body.status;
+  }
+
+  const client = new ArenaClient(auth.arenaToken);
+  try {
+    const channel = await client.createChannel({ title, status });
+    return NextResponse.json(
+      {
+        channel: {
+          id: channel.id,
+          title: channel.title,
+          slug: channel.slug,
+          length: channel.length ?? channel.counts?.contents ?? 0,
+          created_at: channel.created_at,
+          updated_at: channel.updated_at,
+        },
+      },
+      { status: 201 }
+    );
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Failed to create channel";
+    return NextResponse.json({ error: message }, { status: 502 });
   }
 }

--- a/src/app/api/sites/[id]/blocks/route.ts
+++ b/src/app/api/sites/[id]/blocks/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, after } from "next/server";
 import { ArenaClient } from "@/lib/arena";
-import { channelBlocksForTemplate } from "@/lib/build";
+import { buildSite, channelBlocksForTemplate } from "@/lib/build";
 import { prisma } from "@/lib/db";
 import { getRequestAuth } from "@/lib/request-auth";
 
@@ -82,4 +82,118 @@ function editableFieldsForType(
 ): Array<"title" | "description" | "content"> {
   if (type === "text") return ["title", "content"];
   return ["title", "description"];
+}
+
+/**
+ * Create a new block in this site's Are.na channel.
+ *
+ * Body shapes:
+ * - `{ type: "text", content: string, title?: string }`
+ * - `{ type: "link", url: string, title?: string, description?: string }`
+ * - `{ type: "image", url: string, title?: string, description?: string }`
+ *   (URL-based; Are.na fetches the image. Direct file uploads are not in v1.)
+ *
+ * Queues a rebuild on success.
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await getRequestAuth(req);
+  if (!auth) {
+    return NextResponse.json(
+      { error: "Unauthorized", code: "unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const { id } = await params;
+  const site = await prisma.site.findUnique({ where: { id } });
+  if (!site || site.userId !== auth.userId) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  let body: {
+    type?: unknown;
+    content?: unknown;
+    url?: unknown;
+    title?: unknown;
+    description?: unknown;
+    rebuild?: unknown;
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const type = body.type;
+  const title = typeof body.title === "string" ? body.title.slice(0, 500) : undefined;
+  const description =
+    typeof body.description === "string"
+      ? body.description.slice(0, 10_000)
+      : undefined;
+
+  const client = new ArenaClient(auth.arenaToken);
+
+  try {
+    let created;
+    if (type === "text") {
+      const content = typeof body.content === "string" ? body.content.slice(0, 50_000) : "";
+      if (!content.trim()) {
+        return NextResponse.json(
+          { error: "content is required for text blocks" },
+          { status: 400 }
+        );
+      }
+      created = await client.createTextBlock(site.channelSlug, { content, title, description });
+    } else if (type === "link") {
+      const url = typeof body.url === "string" ? body.url.trim() : "";
+      if (!url) {
+        return NextResponse.json(
+          { error: "url is required for link blocks" },
+          { status: 400 }
+        );
+      }
+      created = await client.createLinkBlock(site.channelSlug, { url, title, description });
+    } else if (type === "image") {
+      const url = typeof body.url === "string" ? body.url.trim() : "";
+      if (!url) {
+        return NextResponse.json(
+          { error: "url is required for image blocks (v1 only supports image URLs)" },
+          { status: 400 }
+        );
+      }
+      created = await client.createImageBlockFromUrl(site.channelSlug, { url, title, description });
+    } else {
+      return NextResponse.json(
+        { error: "type must be one of: text, link, image" },
+        { status: 400 }
+      );
+    }
+
+    const shouldRebuild = body.rebuild !== false;
+    if (shouldRebuild) {
+      after(() =>
+        buildSite(id).catch((err) => {
+          console.error("Rebuild after block create failed", id, created.id, err);
+        })
+      );
+    }
+
+    return NextResponse.json(
+      {
+        block: {
+          id: created.id,
+          title: created.title,
+          updated_at: created.updated_at,
+        },
+        rebuildQueued: shouldRebuild,
+      },
+      { status: 201 }
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Failed to create block";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
 }

--- a/src/app/site/new/page.tsx
+++ b/src/app/site/new/page.tsx
@@ -326,6 +326,7 @@ export default function NewSitePage() {
           cancelHref="/sites"
           highlightChannelSlugs={existingSlugs}
           onSelect={handleChannelSelect}
+          enableCreate
         />
       </main>
     );

--- a/src/components/site-channel-picker.tsx
+++ b/src/components/site-channel-picker.tsx
@@ -58,6 +58,7 @@ export function SiteChannelPicker({
   highlightChannelSlugs,
   busy = false,
   embedded = false,
+  enableCreate = false,
 }: {
   onSelect: (channel: SiteChannelPickerChannel) => void;
   cancelHref: string;
@@ -67,7 +68,42 @@ export function SiteChannelPicker({
   busy?: boolean;
   /** Use inside a parent `main` (e.g. admin) — drops outer `min-h-screen` / `main` semantics. */
   embedded?: boolean;
+  /** Show a "New channel" inline composer that creates an Are.na channel via our API and selects it. */
+  enableCreate?: boolean;
 }) {
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createTitle, setCreateTitle] = useState("");
+  const [createStatus, setCreateStatus] = useState<"public" | "closed" | "private">("public");
+  const [createBusy, setCreateBusy] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const submitCreate = async () => {
+    const trimmed = createTitle.trim();
+    if (!trimmed) {
+      setCreateError("Title is required.");
+      return;
+    }
+    setCreateBusy(true);
+    setCreateError(null);
+    try {
+      const res = await fetch("/api/channels", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: trimmed, status: createStatus }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(data.error || `Create failed (${res.status})`);
+      }
+      const data = (await res.json()) as { channel: SiteChannelPickerChannel };
+      onSelect(data.channel);
+    } catch (err) {
+      setCreateError(err instanceof Error ? err.message : "Create failed");
+    } finally {
+      setCreateBusy(false);
+    }
+  };
+
   const [ownChannels, setOwnChannels] = useState<SiteChannelPickerChannel[]>([]);
   const [followingChannels, setFollowingChannels] = useState<
     SiteChannelPickerChannel[]
@@ -142,13 +178,81 @@ export function SiteChannelPicker({
     <div className={rootClass}>
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-lg font-medium">{heading}</h1>
-        <Link
-          href={cancelHref}
-          className="text-sm text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 dark:text-neutral-500"
-        >
-          Cancel
-        </Link>
+        <div className="flex items-center gap-3">
+          {enableCreate && !createOpen && (
+            <button
+              type="button"
+              onClick={() => {
+                setCreateOpen(true);
+                setCreateError(null);
+              }}
+              disabled={busy}
+              className="text-sm text-neutral-600 hover:text-neutral-900 dark:text-neutral-300 dark:hover:text-neutral-50"
+            >
+              + New channel
+            </button>
+          )}
+          <Link
+            href={cancelHref}
+            className="text-sm text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 dark:text-neutral-500"
+          >
+            Cancel
+          </Link>
+        </div>
       </div>
+
+      {enableCreate && createOpen && (
+        <div className="mb-4 space-y-2 rounded border border-neutral-200 bg-neutral-50/60 p-3 dark:border-neutral-700 dark:bg-neutral-900/40">
+          <div className="text-xs font-medium text-neutral-500 dark:text-neutral-400">
+            Create a new Are.na channel
+          </div>
+          <input
+            type="text"
+            value={createTitle}
+            placeholder="Channel title"
+            autoFocus
+            onChange={(e) => setCreateTitle(e.target.value)}
+            className="w-full rounded border border-neutral-200 bg-white px-2 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+          />
+          <div className="flex flex-wrap items-center gap-2 text-xs">
+            <label className="text-neutral-500 dark:text-neutral-400">Visibility</label>
+            <select
+              value={createStatus}
+              onChange={(e) => setCreateStatus(e.target.value as typeof createStatus)}
+              className="rounded border border-neutral-200 bg-white px-2 py-1 dark:border-neutral-700 dark:bg-neutral-950"
+            >
+              <option value="public">Public (anyone)</option>
+              <option value="closed">Closed (collaborators only)</option>
+              <option value="private">Private (only me)</option>
+            </select>
+          </div>
+          <div className="flex items-center gap-2 pt-1">
+            <button
+              type="button"
+              onClick={() => void submitCreate()}
+              disabled={createBusy || !createTitle.trim()}
+              className="inline-flex items-center justify-center rounded border border-neutral-900 bg-neutral-900 px-2.5 py-1 text-xs font-medium text-white hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-100 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-neutral-200"
+            >
+              {createBusy ? "Creating…" : "Create channel"}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setCreateOpen(false);
+                setCreateTitle("");
+                setCreateError(null);
+              }}
+              disabled={createBusy}
+              className="inline-flex items-center justify-center rounded px-2 py-1 text-xs font-medium text-neutral-500 hover:text-neutral-900 disabled:opacity-50 dark:text-neutral-400 dark:hover:text-neutral-100"
+            >
+              Cancel
+            </button>
+            {createError && (
+              <span className="text-[11px] text-red-600 dark:text-red-400">{createError}</span>
+            )}
+          </div>
+        </div>
+      )}
 
       <div className="flex items-center border border-neutral-200 rounded mb-4 focus-within:border-neutral-400 transition-colors dark:focus-within:border-neutral-500 dark:border-neutral-700">
         <select

--- a/src/components/site-content-editor.tsx
+++ b/src/components/site-content-editor.tsx
@@ -34,6 +34,13 @@ type SaveState =
 
 type DraftMap = Record<number, { title?: string; description?: string; content?: string }>;
 
+type NewBlockKind = "text" | "link" | "image";
+
+type CreateState =
+  | { kind: "idle" }
+  | { kind: "saving" }
+  | { kind: "error"; message: string };
+
 function blockTypeLabel(type: EditableBlock["type"]): string {
   switch (type) {
     case "image":
@@ -91,6 +98,14 @@ export function SiteContentEditor({ siteId }: { siteId: string }) {
   const [blocks, setBlocks] = useState<EditableBlock[]>([]);
   const [drafts, setDrafts] = useState<DraftMap>({});
   const [saveState, setSaveState] = useState<Record<number, SaveState>>({});
+
+  const [composerOpen, setComposerOpen] = useState(false);
+  const [newKind, setNewKind] = useState<NewBlockKind>("text");
+  const [newTitle, setNewTitle] = useState("");
+  const [newDescription, setNewDescription] = useState("");
+  const [newContent, setNewContent] = useState("");
+  const [newUrl, setNewUrl] = useState("");
+  const [createState, setCreateState] = useState<CreateState>({ kind: "idle" });
 
   const refreshAll = useCallback(async () => {
     setLoading(true);
@@ -226,18 +241,157 @@ export function SiteContentEditor({ siteId }: { siteId: string }) {
     );
   }
 
+  const resetComposer = () => {
+    setNewTitle("");
+    setNewDescription("");
+    setNewContent("");
+    setNewUrl("");
+    setCreateState({ kind: "idle" });
+  };
+
+  const createBlock = async () => {
+    setCreateState({ kind: "saving" });
+    const body: Record<string, unknown> = { type: newKind };
+    if (newTitle.trim()) body.title = newTitle.trim();
+    if (newDescription.trim()) body.description = newDescription.trim();
+    if (newKind === "text") {
+      if (!newContent.trim()) {
+        setCreateState({ kind: "error", message: "Content is required for a text block." });
+        return;
+      }
+      body.content = newContent;
+    } else {
+      if (!newUrl.trim()) {
+        setCreateState({ kind: "error", message: "URL is required." });
+        return;
+      }
+      body.url = newUrl.trim();
+    }
+
+    try {
+      const res = await fetch(`/api/sites/${siteId}/blocks`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(data.error || `Create failed (${res.status})`);
+      }
+      track("block-created", { siteId, kind: newKind });
+      resetComposer();
+      setComposerOpen(false);
+      await refreshAll();
+    } catch (err) {
+      setCreateState({
+        kind: "error",
+        message: err instanceof Error ? err.message : "Create failed",
+      });
+    }
+  };
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex shrink-0 items-center justify-between gap-2 border-b border-neutral-200 px-4 py-2 text-xs text-neutral-500 dark:border-neutral-800 dark:text-neutral-400">
         <span>{blocks.length} blocks · edits sync to Are.na and queue a rebuild</span>
-        <button
-          type="button"
-          onClick={() => void refreshAll()}
-          className="inline-flex items-center justify-center rounded border border-neutral-200 px-2 py-0.5 text-[11px] font-medium hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800/80"
-        >
-          Refresh
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              setComposerOpen((v) => !v);
+              if (composerOpen) resetComposer();
+            }}
+            className="inline-flex items-center justify-center rounded border border-neutral-200 bg-white px-2 py-0.5 text-[11px] font-medium hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-950 dark:hover:bg-neutral-800/80"
+          >
+            {composerOpen ? "Cancel" : "Add block"}
+          </button>
+          <button
+            type="button"
+            onClick={() => void refreshAll()}
+            className="inline-flex items-center justify-center rounded border border-neutral-200 px-2 py-0.5 text-[11px] font-medium hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800/80"
+          >
+            Refresh
+          </button>
+        </div>
       </div>
+
+      {composerOpen && (
+        <div className="shrink-0 space-y-2 border-b border-neutral-200 bg-neutral-50/60 px-4 py-3 dark:border-neutral-800 dark:bg-neutral-900/40">
+          <div className="flex gap-2 text-xs">
+            {(["text", "link", "image"] as NewBlockKind[]).map((kind) => (
+              <button
+                key={kind}
+                type="button"
+                onClick={() => {
+                  setNewKind(kind);
+                  setCreateState({ kind: "idle" });
+                }}
+                className={`rounded border px-2 py-1 font-medium capitalize ${
+                  newKind === kind
+                    ? "border-neutral-900 bg-neutral-900 text-white dark:border-neutral-100 dark:bg-neutral-100 dark:text-neutral-900"
+                    : "border-neutral-200 bg-white text-neutral-600 hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-300 dark:hover:bg-neutral-800/80"
+                }`}
+              >
+                {kind}
+              </button>
+            ))}
+          </div>
+
+          <input
+            type="text"
+            value={newTitle}
+            placeholder="Title (optional)"
+            onChange={(e) => setNewTitle(e.target.value)}
+            className="w-full rounded border border-neutral-200 bg-white px-2 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+          />
+
+          {newKind === "text" ? (
+            <textarea
+              value={newContent}
+              placeholder="Body text (Markdown supported on Are.na)"
+              rows={4}
+              onChange={(e) => setNewContent(e.target.value)}
+              className="w-full resize-y rounded border border-neutral-200 bg-white px-2 py-1 font-mono text-xs dark:border-neutral-700 dark:bg-neutral-900"
+            />
+          ) : (
+            <>
+              <input
+                type="url"
+                value={newUrl}
+                placeholder={newKind === "image" ? "https://… (image URL)" : "https://…"}
+                onChange={(e) => setNewUrl(e.target.value)}
+                className="w-full rounded border border-neutral-200 bg-white px-2 py-1 font-mono text-xs dark:border-neutral-700 dark:bg-neutral-900"
+              />
+              <textarea
+                value={newDescription}
+                placeholder="Description (optional)"
+                rows={2}
+                onChange={(e) => setNewDescription(e.target.value)}
+                className="w-full resize-y rounded border border-neutral-200 bg-white px-2 py-1 font-mono text-xs dark:border-neutral-700 dark:bg-neutral-900"
+              />
+            </>
+          )}
+
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => void createBlock()}
+              disabled={createState.kind === "saving"}
+              className="inline-flex items-center justify-center rounded border border-neutral-200 bg-white px-2.5 py-1 text-xs font-medium hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-950 dark:hover:bg-neutral-800/80"
+            >
+              {createState.kind === "saving" ? "Adding…" : `Add ${newKind} block`}
+            </button>
+            {createState.kind === "error" && (
+              <span className="text-[11px] text-red-600 dark:text-red-400">{createState.message}</span>
+            )}
+            {newKind === "image" && (
+              <span className="text-[11px] text-neutral-500 dark:text-neutral-400">
+                v1 only accepts image URLs.
+              </span>
+            )}
+          </div>
+        </div>
+      )}
       <ul className="min-h-0 flex-1 divide-y divide-neutral-200 overflow-y-auto dark:divide-neutral-800">
         {blocks.map((block) => {
           const draft = drafts[block.id] || {};

--- a/src/lib/arena.ts
+++ b/src/lib/arena.ts
@@ -175,6 +175,137 @@ export class ArenaClient {
   }
 
   /**
+   * Low-level body+method writer. Same rate-limit retry as `fetch()` but for
+   * POST/PUT/PATCH/DELETE. Returns parsed JSON or null on 204.
+   */
+  private async write<T>(
+    path: string,
+    method: "POST" | "PUT" | "PATCH" | "DELETE",
+    body?: Record<string, unknown>
+  ): Promise<T | null> {
+    const now = Date.now();
+    const elapsed = now - this.lastRequestAt;
+    if (elapsed < this.minInterval) {
+      await sleep(this.minInterval - elapsed);
+    }
+    this.lastRequestAt = Date.now();
+
+    const init: RequestInit = {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        "Content-Type": "application/json",
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    };
+
+    let res = await fetch(`${ARENA_API}${path}`, init);
+    if (res.status === 429) {
+      const resetHeader = res.headers.get("X-RateLimit-Reset");
+      const resetAt = resetHeader
+        ? parseInt(resetHeader, 10) * 1000
+        : Date.now() + 60000;
+      const waitMs = Math.min(Math.max(resetAt - Date.now(), 1000), 60000);
+      await sleep(waitMs);
+      this.lastRequestAt = Date.now();
+      res = await fetch(`${ARENA_API}${path}`, init);
+    }
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(
+        `Are.na ${method} ${path} failed (${res.status} ${res.statusText}): ${text.slice(0, 240)}`
+      );
+    }
+    if (res.status === 204) return null;
+    return (await res.json()) as T;
+  }
+
+  /**
+   * Create a new channel under the authenticated user.
+   *
+   * `status` matches Are.na's terminology: `"public"` (anyone can read),
+   * `"closed"` (read/write only for collaborators), `"private"` (visible only
+   * to the owner).
+   */
+  async createChannel(input: {
+    title: string;
+    status?: "public" | "closed" | "private";
+  }): Promise<ArenaChannel> {
+    const body: Record<string, unknown> = { title: input.title };
+    if (input.status) body.status = input.status;
+    const res = await this.write<ArenaChannel | { data: ArenaChannel }>(
+      "/channels",
+      "POST",
+      body
+    );
+    if (!res) throw new Error("Are.na channel create returned no body");
+    return "data" in res && res.data
+      ? (res as { data: ArenaChannel }).data
+      : (res as ArenaChannel);
+  }
+
+  /** Append a Text block (Markdown allowed) to a channel. */
+  async createTextBlock(
+    channelSlug: string,
+    input: { content: string; title?: string; description?: string }
+  ): Promise<ArenaBlock> {
+    const body: Record<string, unknown> = { content: input.content };
+    if (input.title) body.title = input.title;
+    if (input.description) body.description = input.description;
+    const res = await this.write<ArenaBlock | { data: ArenaBlock }>(
+      `/channels/${encodeURIComponent(channelSlug)}/blocks`,
+      "POST",
+      body
+    );
+    if (!res) throw new Error("Are.na block create returned no body");
+    return "data" in res && res.data
+      ? (res as { data: ArenaBlock }).data
+      : (res as ArenaBlock);
+  }
+
+  /** Append a Link block (URL with optional title/description) to a channel. */
+  async createLinkBlock(
+    channelSlug: string,
+    input: { url: string; title?: string; description?: string }
+  ): Promise<ArenaBlock> {
+    const body: Record<string, unknown> = { source: input.url };
+    if (input.title) body.title = input.title;
+    if (input.description) body.description = input.description;
+    const res = await this.write<ArenaBlock | { data: ArenaBlock }>(
+      `/channels/${encodeURIComponent(channelSlug)}/blocks`,
+      "POST",
+      body
+    );
+    if (!res) throw new Error("Are.na block create returned no body");
+    return "data" in res && res.data
+      ? (res as { data: ArenaBlock }).data
+      : (res as ArenaBlock);
+  }
+
+  /**
+   * Append an Image block from a hosted URL. Are.na fetches the URL server-side
+   * and creates an Image block. Useful when the user pastes an image URL or
+   * after we've uploaded a file to a blob host.
+   */
+  async createImageBlockFromUrl(
+    channelSlug: string,
+    input: { url: string; title?: string; description?: string }
+  ): Promise<ArenaBlock> {
+    const body: Record<string, unknown> = { source: input.url };
+    if (input.title) body.title = input.title;
+    if (input.description) body.description = input.description;
+    const res = await this.write<ArenaBlock | { data: ArenaBlock }>(
+      `/channels/${encodeURIComponent(channelSlug)}/blocks`,
+      "POST",
+      body
+    );
+    if (!res) throw new Error("Are.na block create returned no body");
+    return "data" in res && res.data
+      ? (res as { data: ArenaBlock }).data
+      : (res as ArenaBlock);
+  }
+
+  /**
    * Update a block on Are.na.
    *
    * Are.na's `PUT /blocks/:id` accepts `title`, `description`, and (for Text


### PR DESCRIPTION
## Summary

Extends tiny.garden from a read+edit surface into a full read/edit/**create** surface for Are.na. Users can:

- Create a new Are.na channel from inside `/site/new` (no need to bounce through Are.na's UI to start a site).
- Create new Text / Link / Image-from-URL blocks in their channel from the Content tab on `/sites/[id]`. The new block is pushed to Are.na and a rebuild is queued automatically.

This is feature 2 of 3 from `docs/features.md`. **Stacks on top of #6** — base is `cursor/inline-block-editor` so the create-block composer plugs into the editor that PR 1 introduces. Merge order: PR 1 → PR 2.

## What changed

- `src/lib/arena.ts` — `createChannel`, `createTextBlock`, `createLinkBlock`, `createImageBlockFromUrl`, plus an internal `write()` helper that reuses the existing rate-limit-aware retry for any write verb.
- `src/app/api/channels/route.ts` — adds `POST` alongside the existing `GET`. Body: `{ title, status?: "public" | "closed" | "private" }`. Returns the canonical channel as Are.na reports it.
- `src/app/api/sites/[id]/blocks/route.ts` — adds `POST` alongside the editor's `GET`. Body shapes: `{ type: "text", content, title? }`, `{ type: "link", url, title?, description? }`, `{ type: "image", url, title?, description? }`. Queues a rebuild on success.
- `src/components/site-channel-picker.tsx` — opt-in `enableCreate` prop that adds a **+ New channel** inline composer with title + visibility selector.
- `src/app/site/new/page.tsx` — turns on \`enableCreate\` for the new-site flow.
- `src/components/site-content-editor.tsx` — **Add block** composer above the block list with type tabs (Text / Link / Image), title/description fields, and inline error feedback. On success the composer clears and the list refreshes.

## Scope of v1

- Image blocks: URL-based only. Are.na fetches the URL server-side and creates the Image block. Direct file uploads (browser → blob → Are.na) are explicitly out of scope for v1 — flagged in `docs/features.md` open questions.
- Authorization is the same model as PR 1: site ownership is checked locally; Are.na enforces channel/block permissions and we surface its errors verbatim.

## Test plan

- [ ] On `/site/new` click **+ New channel**, fill title + visibility, submit → channel exists on Are.na, picker proceeds to template selection with it pre-selected.
- [ ] On a site's Content tab, open **Add block**, add a Text block → block appears on Are.na, list refreshes, rebuild runs.
- [ ] Add a Link block with a URL → Are.na resolves the link, rebuild reflects it.
- [ ] Add an Image block with an image URL → Are.na creates an Image block (not a Link) and the image renders in the rebuilt site.
- [ ] Try to create a block in a channel you don't have write access to → error surfaces inline from Are.na.

## Open follow-ups (not in this PR)

- Direct file upload for images (browser → blob → Are.na).
- Drafts that live in tiny.garden before being pushed to Are.na (would be the first time we store user content; called out as an open question in the feature doc).
- Block reordering inside a channel.

Made with [Cursor](https://cursor.com)