### PR TITLE
Migrate lint to ESLint CLI and align CLAUDE.md with PostgreSQL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,6 @@
 ### Gotchas
 
 - The `npm run dev` script includes a `predev` hook that calls `scripts/sync-feature-requests.mjs` (fetches from an external Are.na channel). It fails silently but adds startup latency. Use `npx next dev --port 3000` directly to skip it.
-- The Prisma schema uses PostgreSQL (not SQLite). `CLAUDE.md` mentions SQLite commands for `prisma db push` / `prisma studio` with `DATABASE_URL="file:./dev.db"` — those are outdated. Use the PostgreSQL URL above.
 - Are.na OAuth credentials (`ARENA_CLIENT_ID`, `ARENA_CLIENT_SECRET`) are required to test login/dashboard flows. Without them the app boots and serves public pages (homepage, `/templates`, `/docs`, `/login`) but OAuth redirects will fail.
 - Stripe keys are optional; billing endpoints return 503 gracefully when unconfigured.
 - `BLOB_READ_WRITE_TOKEN` is optional; without it, built sites fall back to local `generated/` directory.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,15 +8,15 @@ tiny.garden turns Are.na channels into static websites. Users log in with Are.na
 
 ## Commands
 
-- `npm run dev` — start dev server on localhost:3000
+- `npm run dev` — start dev server on localhost:3000 (HTTPS; needs local trust setup). For plain HTTP or to skip the `predev` Are.na sync hook, use `npx next dev --port 3000`.
 - `npm run build` — production build
-- `npm run lint` — ESLint
-- `DATABASE_URL="file:./dev.db" npx prisma db push` — apply schema changes
-- `DATABASE_URL="file:./dev.db" npx prisma studio` — browse database
+- `npm run lint` — ESLint (runs `eslint .`; see `eslint.config.mjs`)
+- `npm run db:push` — apply schema changes via Prisma (uses `DATABASE_URL` / `DIRECT_URL` from the environment; same as `npx prisma db push` with those vars set)
+- `DATABASE_URL="postgresql://tinygarden:tinygarden@localhost:5432/tinygarden" npx prisma studio` — browse the database (PostgreSQL must be running)
 
 ## Architecture
 
-**Next.js 15 (App Router) + Tailwind v4 + Prisma (SQLite) + Stripe**
+**Next.js 15 (App Router) + Tailwind v4 + Prisma (PostgreSQL) + Stripe**
 
 ### Core Flow
 1. User authenticates via Are.na OAuth (`/api/auth/login` → `/api/auth/callback`)
@@ -49,7 +49,7 @@ templates/blog/
 The data contract passed to templates is the `SiteData` interface in `src/lib/build.ts`. Block types: `image`, `text`, `link`, `media`, `attachment`. In-app docs: `/docs` (block-type table and per-template notes, including **Gallery** masonry + dialog).
 
 ### Database (Prisma)
-Three models: `User` (Are.na auth + Stripe customer), `Site` (subdomain, channel, template), `Subscription` (free/pro plan).
+PostgreSQL (`prisma/schema.prisma`). Models include `User` (Are.na auth + Stripe customer), `Site` (subdomain, channel, template), `Subscription` (free/pro plan), and others (API tokens, build requests, etc.); see the schema for the full set.
 
 ### Billing
 Stripe checkout + webhooks. Free plan = 1 site. Pro = unlimited. Stripe is lazily initialized (not at module load) to avoid build errors when keys aren't set.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,19 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
 
-const eslintConfig = [...compat.extends("next/core-web-vitals")];
+const eslintConfig = [
+  {
+    ignores: [
+      "node_modules/**",
+      ".next/**",
+      "out/**",
+      "build/**",
+      "next-env.d.ts",
+      "generated/**",
+      "cli/node_modules/**",
+    ],
+  },
+  ...compat.extends("next/core-web-vitals"),
+];
 
 export default eslintConfig;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "db:push": "node scripts/run-prisma.cjs db push",
     "postinstall": "node scripts/prisma-generate.cjs",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "sync:feature-reviews": "node scripts/sync-feature-requests.mjs",
     "cli:build": "npm --prefix cli run build",
     "cli:start": "npm --prefix cli run start --"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This addresses two follow-ups from a recent codebase review: moving off deprecated `next lint`, and making `CLAUDE.md` match the real PostgreSQL + Prisma setup (already documented in `AGENTS.md`).

## Changes

- **`package.json`:** `lint` now runs `eslint .` instead of `next lint`.
- **`eslint.config.mjs`:** Keeps `FlatCompat` with `next/core-web-vitals` (same rule set as before). The `@next/codemod` flat imports for `eslint-config-next` do not work with the published package layout here, so the compat layer was restored. Added ignores for `generated/**` and `cli/node_modules/**`.
- **`package.json`:** Restored `@eslint/eslintrc` as a direct devDependency (required for `FlatCompat`).
- **`CLAUDE.md`:** PostgreSQL commands, `npm run db:push`, Prisma Studio example URL, architecture line, and a short note on `npx next dev` vs `npm run dev`.
- **`AGENTS.md`:** Removed the obsolete gotcha that said `CLAUDE.md` still referenced SQLite.

## Verification

- `npm run lint` passes locally.
- `npm run build` was not run to completion in the agent environment because `DIRECT_URL` is unset (existing Prisma config requirement), not because of these edits.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84ed7b6d-0542-42ad-8762-3ad040bf62fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84ed7b6d-0542-42ad-8762-3ad040bf62fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

