### PR TITLE
fix: retry transient Neon DB errors in cron rebuild

### DIFF
--- a/src/app/api/cron/rebuild/route.ts
+++ b/src/app/api/cron/rebuild/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse, after } from "next/server";
 import type { Prisma } from "@prisma/client";
-import { prisma } from "@/lib/db";
+import { prisma, withDbRetry } from "@/lib/db";
 import { ArenaClient } from "@/lib/arena";
 import { buildSite } from "@/lib/build";
 import { discordTeamNotify } from "@/lib/discord-team-notify";
@@ -57,18 +57,25 @@ async function executeCronRebuild(req: NextRequest): Promise<NextResponse> {
     50
   );
 
-  const total = await prisma.site.count({ where: ELIGIBLE_SITE_WHERE });
+  const total = await withDbRetry(
+    () => prisma.site.count({ where: ELIGIBLE_SITE_WHERE }),
+    { label: "cron/rebuild" }
+  );
   const bucket = Math.floor(Date.now() / rotationMs);
   const effectiveSkip =
     total === 0 ? 0 : ((bucket * batchSize + continuation * batchSize) % total);
 
-  const candidates = await prisma.site.findMany({
-    where: ELIGIBLE_SITE_WHERE,
-    orderBy: { id: "asc" },
-    skip: effectiveSkip,
-    take: batchSize,
-    include: { user: { include: { subscription: true } } },
-  });
+  const candidates = await withDbRetry(
+    () =>
+      prisma.site.findMany({
+        where: ELIGIBLE_SITE_WHERE,
+        orderBy: { id: "asc" },
+        skip: effectiveSkip,
+        take: batchSize,
+        include: { user: { include: { subscription: true } } },
+      }),
+    { label: "cron/rebuild" }
+  );
 
   console.info(
     `[cron/rebuild] phase=start eligible_total=${total} rotation_ms=${rotationMs} time_bucket=${bucket} skip=${effectiveSkip} batch=${batchSize} max_builds=${maxBuilds} candidates=${candidates.length} continuation=${continuation}`

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,7 +1,61 @@
 import { PrismaClient } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 
 const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
 
 export const prisma = globalForPrisma.prisma || new PrismaClient();
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+
+const TRANSIENT_PRISMA_CODES = new Set([
+  "P1001", // Can't reach database server (Neon cold start / network blip)
+  "P1002", // Database server timed out (advisory lock / Neon wake)
+  "P1008", // Operations timed out
+  "P1017", // Server has closed the connection
+]);
+
+function isTransientPrismaError(error: unknown): boolean {
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    return TRANSIENT_PRISMA_CODES.has(error.code);
+  }
+  if (error instanceof Prisma.PrismaClientInitializationError) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Retry a database operation on transient connection errors (P1001, P1002, etc.).
+ * Designed for Neon Postgres cold starts where the first connection attempt may
+ * fail while the database is waking from suspension.
+ */
+export async function withDbRetry<T>(
+  fn: () => Promise<T>,
+  opts?: { maxAttempts?: number; baseDelayMs?: number; label?: string }
+): Promise<T> {
+  const maxAttempts = opts?.maxAttempts ?? 4;
+  const baseDelayMs = opts?.baseDelayMs ?? 2000;
+  const label = opts?.label ?? "db";
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (!isTransientPrismaError(error) || attempt === maxAttempts) {
+        throw error;
+      }
+      const delayMs = baseDelayMs * Math.pow(2, attempt - 1);
+      const code =
+        error instanceof Prisma.PrismaClientKnownRequestError
+          ? error.code
+          : "init_error";
+      console.warn(
+        `[${label}] Transient DB error ${code} on attempt ${attempt}/${maxAttempts}, retrying in ${delayMs}ms…`
+      );
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+  throw lastError;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The cron rebuild handler (`/api/cron/rebuild`) keeps crashing with `P1001` ("Can't reach database server") on the very first database call (`prisma.site.count()`):

```
[cron/rebuild] phase=handler_failed Error [PrismaClientKnownRequestError]:
Invalid `prisma.site.count()` invocation:
Can't reach database server at `ep-bold-hill-akgcwxv5-pooler...`
```

This happens because **Neon Postgres suspends databases after inactivity**. When the cron fires (every 15 min) and no other traffic has kept the DB warm, the first connection attempt times out before Neon finishes waking from suspension. With zero retry logic, the entire cron run fails.

## Fix

**Added `withDbRetry()` utility** to `src/lib/db.ts` — a generic retry wrapper for Prisma operations that catches transient connection errors and retries with exponential backoff:

| Error Code | Meaning |
|---|---|
| `P1001` | Can't reach database server (Neon cold start) |
| `P1002` | Database server timed out (advisory lock / wake) |
| `P1008` | Operations timed out |
| `P1017` | Server has closed the connection |
| `PrismaClientInitializationError` | Connection pool initialization failure |

**Retry strategy:** up to 4 attempts with exponential backoff (2s → 4s → 8s). Total max wait ~14s, well within the 300s `maxDuration`.

**Wrapped the two opening DB queries** in the cron rebuild handler with `withDbRetry`:
- `prisma.site.count()` — the call that was crashing
- `prisma.site.findMany()` — would hit the same issue if count succeeded on a marginal wake

The utility is exported from `src/lib/db.ts` so other handlers can use it if needed.

## Testing

Verified by stopping PostgreSQL to simulate Neon suspension, then bringing it back mid-retry:

| Test | Result |
|---|---|
| **DB wakes mid-retry** (cold start simulation) | P1001 on attempts 1-2, succeeded on attempt 3 → **200 OK** in ~6s |
| **DB stays fully down** (retry exhaustion) | P1001 on all 4 attempts → **500** after ~14s, error surfaced to Discord |

[cron_retry_test_results.log](https://cursor.com/agents/bc-88ee3186-606a-44cc-8946-758d6c197f2d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcron_retry_test_results.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88ee3186-606a-44cc-8946-758d6c197f2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88ee3186-606a-44cc-8946-758d6c197f2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

